### PR TITLE
Type cast encode_hex $str as string

### DIFF
--- a/lib/Hashids/Hashids.php
+++ b/lib/Hashids/Hashids.php
@@ -142,7 +142,7 @@ class Hashids {
 	
 	function encrypt_hex($str) {
 		
-		if (!ctype_xdigit($str))
+		if (!ctype_xdigit((string)$str))
 			return '';
 		
 		$numbers = trim(chunk_split($str, 12, ' '));


### PR DESCRIPTION
When passing in an int, ctype_xdigit returns false, but if cast to string, it passes, as expected
