### PR TITLE
[BUGFIX] Wrong method called in encode_hex()

### DIFF
--- a/lib/Hashids/Hashids.php
+++ b/lib/Hashids/Hashids.php
@@ -163,7 +163,7 @@ class Hashids {
 			$numbers[$i] = hexdec('1' . $number);
 		}
 		
-		return call_user_func_array(array($this, 'decode'), $numbers);
+		return call_user_func_array(array($this, 'encode'), $numbers);
 		
 	}
 	


### PR DESCRIPTION
Changed `decode` to `encode` in `encode_hex()`
