### PR TITLE
travis: run coverage just once

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,11 @@ sudo: false
 install:
   - travis_retry composer install --no-interaction --prefer-source
 
+before_script:
+  - if [ "$TRAVIS_PHP_VERSION" == "5.6" ]; then PHPUNIT_FLAGS="--coverage-clover ./build/logs/clover.xml"; fi
+
 script:
-  - bash -c 'if [ "$TRAVIS_PHP_VERSION" == "hhvm" ]; then vendor/bin/phpunit; fi;'
-  - bash -c 'if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then vendor/bin/phpunit --coverage-clover build/logs/clover.xml; fi;'
+  - vendor/bin/phpunit $PHPUNIT_FLAGS
 
 after_script:
-  - bash -c 'if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then wget https://scrutinizer-ci.com/ocular.phar; fi;'
-  - bash -c 'if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then php ocular.phar code-coverage:upload --format=php-clover build/logs/clover.xml; fi;'
+  - if [ "$TRAVIS_PHP_VERSION" == "5.6" ]; then wget https://scrutinizer-ci.com/ocular.phar && php ocular.phar code-coverage:upload --format=php-clover build/logs/clover.xml; fi


### PR DESCRIPTION
Running coverage just once is usually sufficient. Similar PR for Doctrine - see https://github.com/doctrine/doctrine2/pull/1251

Also, where is this coverage actually used? Looks like the projects is not even activated on Scrutinizer - https://scrutinizer-ci.com/g/vinkla/hashids

In case it would be active, I'd add also coverage badge to README.md