### PR TITLE
Add decodeSingle method

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,23 @@ $hex = $hashids->decodeHex($id); // 507f1f77bcf86cd799439011
 
 	$hashids->decode($id); // [1]
 	```
+ 
+   If you are certain the hash contains only one encoded value, you can use the `decodeSingle()` function.
+   It returns an integer for a hash containing a single encoded value, and null otherwise (either an invalid hash or one containing multiple encoded values).
+   
+   ```php
+   use Hashids\Hashids;
+   
+   $hashids = new Hashids();
+   
+   $singleValueHash = $hashids->encode(1);
+   $multipleValueHash = $hashids->encode([1, 2]);
+   
+   $hashids->decodeSingle($id); // 1
+   $hashids->decodeSingle(''); // null
+   $hashids->decodeSingle($multipleValueHash); // null
+   ```
+   
 
 2. Encoding negative numbers is not supported.
 3. If you pass bogus input to `encode()`, an empty string will be returned:

--- a/src/Hashids.php
+++ b/src/Hashids.php
@@ -266,6 +266,21 @@ class Hashids implements HashidsInterface
     }
 
     /**
+     * Decode a hash and only return one number.
+     * If it's an invalid hash or a hash with multiple encoded values, return null.
+     *
+     * @param string $hash
+     *
+     * @return int|null
+     */
+    public function decodeSingle($hash)
+    {
+        $ret = $this->decode($hash);
+
+        return count($ret) === 1 ? $ret[0] : null;
+    }
+
+    /**
      * Encode hexadecimal values and generate a hash string.
      *
      * @param string $str

--- a/tests/HashidsTest.php
+++ b/tests/HashidsTest.php
@@ -353,4 +353,19 @@ class HashidsTest extends TestCase
         $encoded = $hashids->encode(1);
         $this->assertEquals('DngB0NV05ev1', $encoded);
     }
+
+    public function testDecodeSingle()
+    {
+        $hashids = new Hashids();
+
+        $singleIdHash = $hashids->encode(1);
+        $multipleIdHash = $hashids->encode([1,2]);
+
+        // Return single integer for single-value hash
+        $this->assertEquals(1, $hashids->decodeSingle($singleIdHash));
+
+        // Return null for invalid hash or multiple value hash
+        $this->assertEquals(null, $hashids->decodeSingle(''));
+        $this->assertEquals(null, $hashids->decodeSingle($multipleIdHash));
+    }
 }

--- a/tests/HashidsTest.php
+++ b/tests/HashidsTest.php
@@ -359,7 +359,7 @@ class HashidsTest extends TestCase
         $hashids = new Hashids();
 
         $singleIdHash = $hashids->encode(1);
-        $multipleIdHash = $hashids->encode([1,2]);
+        $multipleIdHash = $hashids->encode([1, 2]);
 
         // Return single integer for single-value hash
         $this->assertEquals(1, $hashids->decodeSingle($singleIdHash));


### PR DESCRIPTION
I added a simple convenience function for decoding a single value from a hash.

The behaviour is as follows:
- if the hash contains a single encoded value, return said value
- if the hash is invalid, return null
- if the hash contains multiple encoded values, return null

This is to alleviate the mentioned pitfall of the library always returning an array. While the workaround is trivial, I thought having the method baked in would be even better.

A second consideration is the [Laravel integration](https://github.com/vinkla/laravel-hashids). I ended up adding this method in a project I'm working on by extending the Facade. This worked (kinda), but led to another pitfall. In use cases where I needed to reference another connection, the method didn't exist, because the expression was resolving to an actual Hashids instance, and not delegating the call through the Facade, i.e.

```php
// Works, because the method is on the facade, which calls decode on itself,
// which actually delegates to a manager and eventually to a Hashids instance
Hashids::decodeSingle('hash');

// Doesn't work. The connection() method call returns a simple Hashids instance, which
// doesn't have the method.
Hashids::connection('not_main')->decodeSingle('hash');
```

I realized that in order to make it work with the fluent API, I'd have to extend the Hashids class and the Facade class (maybe the Manager class for good measure), which would basically amount to a fork. Might as well submit a pull request.

Should you choose to merge this, I'll submit a pull request for the Laravel package as well, updating the PHPDoc for the required classes.

Cheers!