### PR TITLE
encode_hex not working in PHP

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        php: [7.2, 7.3, 7.4]
+        php: [7.2, 7.3, 7.4, 8.0]
         extension: [':bcmath', ':gmp']
 
     name: PHP ${{ matrix.php }}

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.2 || ^8.0",
         "ext-mbstring": "*"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "ext-mbstring": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.0",
+        "phpunit/phpunit": "^8.0 || ^9.0",
         "squizlabs/php_codesniffer": "^3.5"
     },
     "suggest": {


### PR DESCRIPTION
It returns blank when I use:

```
$hashids = new Hashids\Hashids();
$hashed_text = $hashids->encode_hex("63706b64");

echo $hashed_text;
```
But it gets hashed when I try:-

```
$hashids = new Hashids\Hashids();
$hashed_text = $hashids->encode_hex("63706b");

echo $hashed_text;
```