### PR TITLE
Added a failing test for custom alphabet and long salt

### DIFF
--- a/tests/HashidsTest.php
+++ b/tests/HashidsTest.php
@@ -348,4 +348,14 @@ class HashidsTest extends TestCase
         $encoded = $hashids->encode(1);
         $this->assertEquals('DngB0NV05ev1', $encoded);
     }
+	
+	public function testLongSaltWithCustomAlphabet()
+	{
+		$alphabet = "bcdfghjkmnpqrstvwxz23456789";
+		$a = new Hashids("aaaaaaaaaaaaaaaaaaaaaaaaaaaa", 5, $alphabet);
+		$b = new Hashids("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", 5, $alphabet);
+		$encodedA = $a->encode(1);
+		$encodedB = $b->encode(1);
+		$this->assertNotEquals($encodedA, $encodedB);
+	}
 }


### PR DESCRIPTION
PR to demostrate an error with different salt generating the same code.

It generates the same code, no matter how many 'a' you append to the salt of the last hashids instance.

Expected behavior: codes should be different (every salt should generate a different code)
Note: Using short salt always generate different codes.


