### PR TITLE
fix phpdoc types for encode method

### DIFF
--- a/src/Hashids.php
+++ b/src/Hashids.php
@@ -80,7 +80,7 @@ class Hashids implements HashidsInterface
     /**
      * Encode parameters to generate a hash.
      *
-     * @param string|array<int, string> $numbers
+     * @param int|string|array<int, int|string> $numbers
      */
     public function encode(...$numbers): string
     {

--- a/src/HashidsInterface.php
+++ b/src/HashidsInterface.php
@@ -15,7 +15,7 @@ interface HashidsInterface
 {
     /**
      * Encode parameters to generate a hash.
-     * @param string|array<int, string> $numbers
+     * @param int|string|array<int, int|string> $numbers
      */
     public function encode(...$numbers): string;
 


### PR DESCRIPTION
using a static analysis tool like phpstan will give you a type error. this bug occurs in version 5.0.0.