### PR TITLE
Fix the data provider to test both Gmp and BCMath when both extensions are installed

### DIFF
--- a/tests/MathTest.php
+++ b/tests/MathTest.php
@@ -20,16 +20,17 @@ class MathTest extends TestCase
 {
     public static function mathProvider()
     {
+        $providerCases = [];
         if (extension_loaded('gmp')) {
-            return [
-                [new Gmp()]
-            ];
+            $providerCases[] = [new Gmp()];
         }
 
         if (extension_loaded('bcmath')) {
-            return [
-                [new BCMath()]
-            ];
+            $providerCases[] = [new BCMath()];
+        }
+
+        if (count($providerCases) > 0) {
+            return $providerCases;
         }
 
         throw new RuntimeException('Missing math extension for Hashids, install either bcmath or gmp.');


### PR DESCRIPTION
Tests should run for both implementations when possible.