### PR TITLE
improve some types on phpdoc

### DIFF
--- a/src/Hashids.php
+++ b/src/Hashids.php
@@ -77,7 +77,6 @@ class Hashids implements HashidsInterface
         }
     }
 
-    /** Encode parameters to generate a hash. */
     public function encode(...$numbers): string
     {
         $ret = '';
@@ -146,7 +145,6 @@ class Hashids implements HashidsInterface
         return $ret;
     }
 
-    /** Decode a hash to the original parameter values. */
     public function decode(string $hash): array
     {
         $ret = [];
@@ -189,7 +187,6 @@ class Hashids implements HashidsInterface
         return $ret;
     }
 
-    /** Encode hexadecimal values and generate a hash string. */
     public function encodeHex(string $str): string
     {
         if (!ctype_xdigit($str)) {
@@ -206,7 +203,6 @@ class Hashids implements HashidsInterface
         return $this->encode(...$numbers);
     }
 
-    /** Decode a hexadecimal hash. */
     public function decodeHex(string $hash): string
     {
         $ret = '';

--- a/src/Hashids.php
+++ b/src/Hashids.php
@@ -79,8 +79,7 @@ class Hashids implements HashidsInterface
 
     /**
      * Encode parameters to generate a hash.
-     *
-     * @param int|string|array<int, int|string> $numbers
+     * @param int|string|array<int, int|string> ...$numbers
      */
     public function encode(...$numbers): string
     {

--- a/src/Hashids.php
+++ b/src/Hashids.php
@@ -151,7 +151,7 @@ class Hashids implements HashidsInterface
 
     /**
      * Decode a hash to the original parameter values.
-     * @return array<int, string>
+     * @return array<int, int>|array{}
      */
     public function decode(string $hash): array
     {

--- a/src/Hashids.php
+++ b/src/Hashids.php
@@ -77,10 +77,7 @@ class Hashids implements HashidsInterface
         }
     }
 
-    /**
-     * Encode parameters to generate a hash.
-     * @param int|string|array<int, int|string> ...$numbers
-     */
+    /** Encode parameters to generate a hash. */
     public function encode(...$numbers): string
     {
         $ret = '';
@@ -149,10 +146,7 @@ class Hashids implements HashidsInterface
         return $ret;
     }
 
-    /**
-     * Decode a hash to the original parameter values.
-     * @return array<int, int>|array{}
-     */
+    /** Decode a hash to the original parameter values. */
     public function decode(string $hash): array
     {
         $ret = [];

--- a/src/HashidsInterface.php
+++ b/src/HashidsInterface.php
@@ -15,7 +15,7 @@ interface HashidsInterface
 {
     /**
      * Encode parameters to generate a hash.
-     * @param int|string|array<int, int|string> $numbers
+     * @param int|string|array<int, int|string> ...$numbers
      */
     public function encode(...$numbers): string;
 

--- a/src/HashidsInterface.php
+++ b/src/HashidsInterface.php
@@ -19,7 +19,10 @@ interface HashidsInterface
      */
     public function encode(...$numbers): string;
 
-    /** Decode a hash to the original parameter values. */
+    /**
+     * Decode a hash to the original parameter values.
+     * @return array<int, int>|array{}
+     */
     public function decode(string $hash): array;
 
     /** Encode hexadecimal values and generate a hash string. */


### PR DESCRIPTION
fixed a mistake in the type of the argument of the encode method. also, there was an error in the return value type of the decode method, so I fixed it.

`array{}` means an empty array. this is fine without it, but it makes it explicit that an empty array can also be returned. you can remove it if you don't like it.