### PR TITLE
decodeToString method, for simple decoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ $hashids = new Hashids();
 
 $id = $hashids->encode(1, 2, 3); // o2fXhV
 $numbers = $hashids->decode($id); // [1, 2, 3]
+or
+$numbers = $hashids->decodeToString($id); // 123
 ```
 
 ## More Options
@@ -115,6 +117,12 @@ $hex = $hashids->decodeHex($id); // 507f1f77bcf86cd799439011
 
 	$hashids->decode($id); // [1]
 	```
+     You can use
+    ```php
+    $hashids->decodeToString($id); // 1    
+    ```
+   to get simple string, which is imploded array of decode;
+
 
 2. Encoding negative numbers is not supported.
 3. If you pass bogus input to `encode()`, an empty string will be returned:

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ $hashids = new Hashids();
 
 $id = $hashids->encode(1, 2, 3); // o2fXhV
 $numbers = $hashids->decode($id); // [1, 2, 3]
-or
+// or
 $numbers = $hashids->decodeToString($id); // 123
 ```
 
@@ -121,7 +121,7 @@ $hex = $hashids->decodeHex($id); // 507f1f77bcf86cd799439011
     ```php
     $hashids->decodeToString($id); // 1    
     ```
-   to get simple string, which is imploded array of decode;
+   to get simple string, which is helper, to imploded result of decode method;
 
 
 2. Encoding negative numbers is not supported.

--- a/src/Hashids.php
+++ b/src/Hashids.php
@@ -187,6 +187,11 @@ class Hashids implements HashidsInterface
         return $ret;
     }
 
+    public function decodeToString(string $hash): string
+    {
+        return implode($this->decode($hash));
+    }
+
     public function encodeHex(string $str): string
     {
         if (!ctype_xdigit($str)) {

--- a/src/HashidsInterface.php
+++ b/src/HashidsInterface.php
@@ -25,6 +25,11 @@ interface HashidsInterface
      */
     public function decode(string $hash): array;
 
+    /**
+     * Decode a hash to the string, with concatenated original parameter values.
+     */
+    public function decodeToString(string $hash): string;
+
     /** Encode hexadecimal values and generate a hash string. */
     public function encodeHex(string $str): string;
 

--- a/tests/HashidsTest.php
+++ b/tests/HashidsTest.php
@@ -46,8 +46,8 @@ class HashidsTest extends TestCase
         $this->assertSame([], $hashids->decode(''));
         $this->assertSame([], $hashids->decode('f'));
 
-        $this->assertSame([], $hashids->decodeToString(''));
-        $this->assertSame([], $hashids->decodeToString('f'));
+        $this->assertSame('', $hashids->decodeToString(''));
+        $this->assertSame('', $hashids->decodeToString('f'));
 
         $this->assertSame('', $hashids->encodeHex('z'));
 

--- a/tests/HashidsTest.php
+++ b/tests/HashidsTest.php
@@ -46,9 +46,14 @@ class HashidsTest extends TestCase
         $this->assertSame([], $hashids->decode(''));
         $this->assertSame([], $hashids->decode('f'));
 
+        $this->assertSame([], $hashids->decodeToString(''));
+        $this->assertSame([], $hashids->decodeToString('f'));
+
         $this->assertSame('', $hashids->encodeHex('z'));
 
         $this->assertSame('', $hashids->decodeHex('f'));
+
+        $this->noMethod('test');
     }
 
     public static function alphabetProvider()
@@ -180,6 +185,19 @@ class HashidsTest extends TestCase
         $this->assertSame($id, $encodedId);
         $this->assertSame($id, call_user_func_array([$hashids, 'encode'], $numbers));
         $this->assertSame($numbers, $decodedNumbers);
+    }
+
+
+    /** @dataProvider defaultParamsProvider */
+    public function testDecodeToString($id, $numbers)
+    {
+        $hashids = new Hashids();
+
+        $implodedNum = implode($numbers);
+        $encodedId = $hashids->encode($numbers);
+        $decodedNumber = $hashids->decodeToString($encodedId);
+
+        $this->assertSame($implodedNum, $decodedNumber);
     }
 
     public static function customParamsProvider()

--- a/tests/HashidsTest.php
+++ b/tests/HashidsTest.php
@@ -52,8 +52,6 @@ class HashidsTest extends TestCase
         $this->assertSame('', $hashids->encodeHex('z'));
 
         $this->assertSame('', $hashids->decodeHex('f'));
-
-        $this->noMethod('test');
     }
 
     public static function alphabetProvider()


### PR DESCRIPTION
My case of using your lib is usually encode/decode simple integer ID. So after every decode i have to get first value of this array. I never used array of decoded variables so need at simple method which will just return me string of imploded values of decode.

I used my own class, which extends lib, on my projects, but want to offer you little function to add this functional )

I added simple method like helper.
```
public function decodeToString(string $hash): string
{
    return implode($this->decode($hash));
}
```

Tests was extended also :)