### PR TITLE
Add Support for Encoding and Decoding Arbitrary Strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,19 @@ $id = $hashids->encodeHex('507f1f77bcf86cd799439011'); // y42LW46J9luq3Xq9XMly
 $hex = $hashids->decodeHex($id); // 507f1f77bcf86cd799439011
 ```
 
+#### Encode string instead of numbers
+
+Useful if you want to encode [Mongo](https://www.mongodb.com)'s ObjectIds. Note that *there is no limit* on how large of a hex number you can pass (it does not have to be Mongo's ObjectId).
+
+```php
+use Hashids\Hashids;
+
+$hashids = new Hashids();
+
+$id = $hashids->encodeString('encode decode string'); // llKJwwjNPAUjRXRzM4ryH0pZ7p2xWEHM1K8
+$hex = $hashids->decodeString($id); // encode decode string
+```
+
 ## Pitfalls
 
 1. When decoding, output is always an array of numbers (even if you encoded only one number):

--- a/src/Hashids.php
+++ b/src/Hashids.php
@@ -215,6 +215,22 @@ class Hashids implements HashidsInterface
         return $ret;
     }
 
+    public function encodeString(string $str): string
+    {
+        $hexStr = bin2hex($str);
+        return $this->encodeHex($hexStr);
+    }
+
+    public function decodeString(string $hash): string
+    {
+        $hexStr = $this->decodeHex($hash);
+        $ret = hex2bin($hexStr);
+        if ($ret === false) {
+            return '';
+        }
+        return $ret;
+    }
+
     /** Shuffle alphabet by given salt. */
     protected function shuffle(string $alphabet, string $salt): string
     {

--- a/src/HashidsInterface.php
+++ b/src/HashidsInterface.php
@@ -30,4 +30,10 @@ interface HashidsInterface
 
     /** Decode a hexadecimal hash. */
     public function decodeHex(string $hash): string;
+
+    /** Encode arbitrary string values and generate a hash string. */
+    public function encodeString(string $str): string;
+
+    /** Decode an arbitrary string hash. */
+    public function decodeString(string $hash): string;
 }

--- a/tests/HashidsTest.php
+++ b/tests/HashidsTest.php
@@ -49,6 +49,8 @@ class HashidsTest extends TestCase
         $this->assertSame('', $hashids->encodeHex('z'));
 
         $this->assertSame('', $hashids->decodeHex('f'));
+
+        $this->assertSame('', $hashids->decodeHex('f'));
     }
 
     public static function alphabetProvider()
@@ -242,6 +244,32 @@ class HashidsTest extends TestCase
 
         $this->assertSame($id, $encodedId);
         $this->assertSame(strtolower($hex), $decodedHex);
+    }
+
+    public static function defaultParamsStringProvider()
+    {
+        return [
+            ['MwLNMNmXm', 'hello'],
+            ['RlgMvxEkR', 'world'],
+            ['RvAQEOX6GVcRV', 'Hashids'],
+            ['WEo7Q87k1piOyVk9By3PIpyxql', 'PHPUnit testing'],
+            ['llKJwwjNPAUjRXRzM4ryH0pZ7p2xWEHM1K8', 'encode decode string'],
+            ['BmDo4pEjWjH5jDnnv', '1234567890'],
+            ['qqyxMWW1yQsZW92317O9izwNV0Bow9uVjgE6oON5', 'complex test case string'],
+            ['vBvqKrRkmKfxAnQ3ymmjI4nmwpENnzHnMrXVAQG1SXVR8zrlJkiwk6AyRAqEUJR83ngX9', 'long string with special chars !@#$%^&*()'],
+        ];
+    }
+
+    /** @dataProvider defaultParamsStringProvider */
+    public function testDefaultParamsString($id, $string)
+    {
+        $hashids = new Hashids();
+
+        $encodedString = $hashids->encodeString($string);
+        $decodedString = $hashids->decodeString($encodedString);
+
+        $this->assertSame($id, $encodedString);
+        $this->assertSame($string, $decodedString);
     }
 
     public static function customParamsHexProvider()

--- a/tests/HashidsTest.php
+++ b/tests/HashidsTest.php
@@ -49,8 +49,6 @@ class HashidsTest extends TestCase
         $this->assertSame('', $hashids->encodeHex('z'));
 
         $this->assertSame('', $hashids->decodeHex('f'));
-
-        $this->assertSame('', $hashids->decodeHex('f'));
     }
 
     public static function alphabetProvider()


### PR DESCRIPTION
## Description of Changes

This pull request introduces the ability to encode and decode arbitrary strings, expanding the library's functionality beyond hexadecimal encoding. With these changes, users can now directly handle strings, without needing to convert them to numeric or hexadecimal formats.

### Key Changes

1. **New Methods for String Encoding and Decoding**:
   - **`encodeString`**: Encodes an arbitrary string into a hash. Internally, the string is first converted to its hexadecimal representation using `bin2hex()`, then passed to the existing `encodeHex` method.
   - **`decodeString`**: Decodes a hash back into its original string by decoding the hash using `decodeHex`, and then converting the result back into a string using `hex2bin()`.

2. **Interface Update**:
   - The `HashidsInterface` has been updated to include the new `encodeString` and `decodeString` methods, ensuring that any class implementing this interface will support these new features.

### Example Usage

The following example demonstrates how to encode and decode a string using the new methods:

```php
use Hashids\Hashids;

$hashids = new Hashids();

$encodedString = $hashids->encodeString('encode decode string'); // llKJwwjNPAUjRXRzM4ryH0pZ7p2xWEHM1K8
$decodedString = $hashids->decodeString($encodedString); // encode decode string
