### PR TITLE
fix(readme): correct installation command for Laravel

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 Require this package, with [Composer](https://getcomposer.org), in the root directory of your project.
 
 ```bash
-composer require hashids/hashids
+composer require vinkla/hashids
 ```
 
 Then you can import the class into your application:


### PR DESCRIPTION
### Summary
This PR updates the README to use the correct installation command for Laravel users:
- Changed `composer require hashids/hashids` to `composer require vinkla/hashids`.

### Why?
The `hashids/hashids` package is the core Hashids implementation, but Laravel users should install `vinkla/hashids`, which provides proper Laravel integration.

### Impact
This improves clarity and prevents installation issues for Laravel developers.

Let me know if any modifications are needed!
