### PR TITLE
PHPunit 12.x support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "ext-mbstring": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.5|^11.2"
+        "phpunit/phpunit": "^10.5|^11.2|^12.0"
     },
     "suggest": {
         "ext-bcmath": "Required to use BC Math arbitrary precision mathematics (*).",

--- a/tests/HashidsTest.php
+++ b/tests/HashidsTest.php
@@ -14,6 +14,7 @@ namespace Hashids\Tests;
 use Hashids\Hashids;
 use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\RequiresFunction;
 use PHPUnit\Framework\TestCase;
 
 class HashidsTest extends TestCase
@@ -317,9 +318,7 @@ class HashidsTest extends TestCase
         $this->assertEquals($hash, $hashids->encode($numbers));
     }
 
-    /**
-     * @requires function bcscale
-     */
+    #[RequiresFunction('bcscale')]
     public function testBehaviourForDifferentBCMathAccuracy()
     {
         bcscale(2);

--- a/tests/HashidsTest.php
+++ b/tests/HashidsTest.php
@@ -13,6 +13,7 @@ namespace Hashids\Tests;
 
 use Hashids\Hashids;
 use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class HashidsTest extends TestCase
@@ -64,7 +65,7 @@ class HashidsTest extends TestCase
         ];
     }
 
-    /** @dataProvider alphabetProvider */
+    #[DataProvider('alphabetProvider')]
     public function testAlphabet($alphabets)
     {
         $numbers = [1, 2, 3];
@@ -88,7 +89,7 @@ class HashidsTest extends TestCase
         ];
     }
 
-    /** @dataProvider saltProvider */
+    #[DataProvider('saltProvider')]
     public function testSalt($salts)
     {
         $numbers = [1, 2, 3];
@@ -111,7 +112,7 @@ class HashidsTest extends TestCase
         ];
     }
 
-    /** @dataProvider minLengthProvider */
+    #[DataProvider('minLengthProvider')]
     public function testMinLength($lengths)
     {
         $numbers = [1, 2, 3];
@@ -133,7 +134,7 @@ class HashidsTest extends TestCase
         ];
     }
 
-    /** @dataProvider encodeTypesProvider */
+    #[DataProvider('encodeTypesProvider')]
     public function testEncodeTypes($params)
     {
         $numbers = [1, 2, 3];
@@ -169,7 +170,7 @@ class HashidsTest extends TestCase
         ];
     }
 
-    /** @dataProvider defaultParamsProvider */
+    #[DataProvider('defaultParamsProvider')]
     public function testDefaultParams($id, $numbers)
     {
         $hashids = new Hashids();
@@ -202,7 +203,7 @@ class HashidsTest extends TestCase
         ];
     }
 
-    /** @dataProvider customParamsProvider */
+    #[DataProvider('customParamsProvider')]
     public function testCustomParams($id, $numbers)
     {
         $minLength = 30;
@@ -232,7 +233,7 @@ class HashidsTest extends TestCase
         ];
     }
 
-    /** @dataProvider defaultParamsHexProvider */
+    #[DataProvider('defaultParamsHexProvider')]
     public function testDefaultParamsHex($id, $hex)
     {
         $hashids = new Hashids();
@@ -258,7 +259,7 @@ class HashidsTest extends TestCase
         ];
     }
 
-    /** @dataProvider customParamsHexProvider */
+    #[DataProvider('customParamsHexProvider')]
     public function testCustomParamsHex($id, $hex)
     {
         $minLength = 30;
@@ -283,7 +284,7 @@ class HashidsTest extends TestCase
         ];
     }
 
-    /** @dataProvider bigNumberDataProvider */
+    #[DataProvider('bigNumberDataProvider')]
     public function testBigNumberEncode($number, $hash)
     {
         $hashids = new Hashids('this is my salt');
@@ -291,7 +292,7 @@ class HashidsTest extends TestCase
         $this->assertEquals($hash, $encoded);
     }
 
-    /** @dataProvider bigNumberDataProvider */
+    #[DataProvider('bigNumberDataProvider')]
     public function testBigNumberDecode($number, $hash)
     {
         $hashids = new Hashids('this is my salt');
@@ -309,7 +310,7 @@ class HashidsTest extends TestCase
         ];
     }
 
-    /** @dataProvider jsHashidsDataProvider */
+    #[DataProvider('jsHashidsDataProvider')]
     public function testJsHashidsCompatible($salt, $minHashLength, $alphabet, $numbers, $hash)
     {
         $hashids = new Hashids($salt, $minHashLength, $alphabet);

--- a/tests/MathTest.php
+++ b/tests/MathTest.php
@@ -13,6 +13,7 @@ namespace Hashids\Tests;
 
 use Hashids\Math\BCMath;
 use Hashids\Math\Gmp;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
@@ -36,25 +37,25 @@ class MathTest extends TestCase
         throw new RuntimeException('Missing math extension for Hashids, install either bcmath or gmp.');
     }
 
-    /** @dataProvider mathProvider */
+    #[DataProvider('mathProvider')]
     public function testAdd($math)
     {
         $this->assertEquals($math->get(3), $math->add(1, 2));
     }
 
-    /** @dataProvider mathProvider */
+    #[DataProvider('mathProvider')]
     public function testMultiply($math)
     {
         $this->assertEquals($math->get(12), $math->multiply(2, 6));
     }
 
-    /** @dataProvider mathProvider */
+    #[DataProvider('mathProvider')]
     public function testDivide($math)
     {
         $this->assertEquals($math->get(2), $math->divide(4, 2));
     }
 
-    /** @dataProvider mathProvider */
+    #[DataProvider('mathProvider')]
     public function testGreaterThan($math)
     {
         $this->assertTrue($math->greaterThan('18446744073709551615', '9223372036854775807'));
@@ -62,19 +63,19 @@ class MathTest extends TestCase
         $this->assertFalse($math->greaterThan('9223372036854775807', '9223372036854775807'));
     }
 
-    /** @dataProvider mathProvider */
+    #[DataProvider('mathProvider')]
     public function testMod($math)
     {
         $this->assertEquals($math->get(15), $math->mod('18446744073709551615', '100'));
     }
 
-    /** @dataProvider mathProvider */
+    #[DataProvider('mathProvider')]
     public function testIntval($math)
     {
         $this->assertSame(9223372036854775807, $math->intval('9223372036854775807'));
     }
 
-    /** @dataProvider mathProvider */
+    #[DataProvider('mathProvider')]
     public function testStrval($math)
     {
         $this->assertSame('18446744073709551615', $math->strval($math->add('0', '18446744073709551615')));


### PR DESCRIPTION
Hi,

Since Laravel 13 has been released and now uses PHPUnit 12.x, I opened this PR to make the package compatible with it.

I also migrated the tests from the legacy PHPUnit annotations to the newer attribute-based syntax.